### PR TITLE
Hotfix

### DIFF
--- a/adk/data/include/AxisBlock.h
+++ b/adk/data/include/AxisBlock.h
@@ -20,7 +20,7 @@ class AxisBlock : public Block {
         _friction = property.friction;
         _light_emission = property.light_emission;
         _loot = property.loot;
-        _color = property.colour;
+        _color = property.color;
         _rotation = property.rotation;
     }
 

--- a/adk/data/include/Block.h
+++ b/adk/data/include/Block.h
@@ -38,7 +38,7 @@ class Block {
         _friction = property.friction;
         _light_emission = property.light_emission;
         _loot = property.loot;
-        _color = property.colour;
+        _color = property.color;
         _rotation = property.rotation;
     }
 
@@ -64,7 +64,7 @@ class Block {
             j["minecraft:block"]["components"]
              ["minecraft:destructible_by_explosion"] = _explosion;
 
-        if (_mining != json::object_t({{"seconds_to_destory", 0.0}}))
+        if (_mining != json::object_t({{"seconds_to_destroy", 0.0}}))
             j["minecraft:block"]["components"]
              ["minecraft:destructible_by_mining"] = _mining;
 

--- a/adk/data/include/BlockProperty.h
+++ b/adk/data/include/BlockProperty.h
@@ -15,7 +15,7 @@ class BlockProperty {
         nlohmann::json::object_t crafting = {
             {"crafting_table", {"crafting_table"}}, {"table_name", "Foo Bar"}};
         nlohmann::json::object_t explosion = {{"explosion_resistance", 0}};
-        nlohmann::json::object_t mining = {{"seconds_to_destory", 0.0}};
+        nlohmann::json::object_t mining = {{"seconds_to_destroy", 0.0}};
         std::string display_name = "";
         nlohmann::json::object_t flammable = {{"catch_chance_modifier", 5},
                                               {"destroy_chance_modifier", 20}};
@@ -23,7 +23,7 @@ class BlockProperty {
         std::string geometry = "";
         int light_emission = 0;
         std::string loot = "";
-        std::string colour = "";
+        std::string color = "";
         std::vector<int> rotation = {0, 0, 0};
 
         /// @brief Sets "light_dampening" component
@@ -66,7 +66,7 @@ class BlockProperty {
         /// @param m Sets the number of seconds it takes to destroy the block
         /// with base equipment. Greater numbers result in greater mining times.
         Property setMining(float m) {
-            this->mining = {{"seconds_to_destory", m}};
+            this->mining = {{"seconds_to_destroy", m}};
             return *this;
         }
 
@@ -144,8 +144,8 @@ class BlockProperty {
         /// @param c Sets the color of the block when rendered to a map. The
         /// color is represented as a hex value in the format "#RRGGBB". If this
         /// component is omitted, the block will not show up on the map.
-        Property setColour(std::string c) {
-            this->colour = c;
+        Property setColor(std::string c) {
+            this->color = c;
             return *this;
         }
 

--- a/adk/data/include/BushBlock.h
+++ b/adk/data/include/BushBlock.h
@@ -20,7 +20,7 @@ class BushBlock : public Block {
         _friction = property.friction;
         _light_emission = property.light_emission;
         _loot = property.loot;
-        _color = property.colour;
+        _color = property.color;
         _rotation = property.rotation;
     }
 

--- a/adk/data/include/CandleBlock.h
+++ b/adk/data/include/CandleBlock.h
@@ -20,7 +20,7 @@ class CandleBlock : public Block {
         _friction = property.friction;
         _light_emission = property.light_emission;
         _loot = property.loot;
-        _color = property.colour;
+        _color = property.color;
         _rotation = property.rotation;
     }
 
@@ -56,6 +56,8 @@ class CandleBlock : public Block {
          ["set_block_property"][mod_id + ":count"] =
              "(q.block_property('" + mod_id +
              ":count') < 4) ? q.block_property('" + mod_id + ":count') + 1 : 4";
+        j["minecraft"]["events"][mod_id + ":add_candle"]["decrement_stack"] =
+            json::object();
 
         // Permutations
         j["minecraft:block"]["permutations"].push_back(

--- a/adk/data/include/GlassBlock.h
+++ b/adk/data/include/GlassBlock.h
@@ -24,7 +24,7 @@ class GlassBlock : public Block {
         _friction = property.friction;
         _light_emission = property.light_emission;
         _loot = property.loot;
-        _color = property.colour;
+        _color = property.color;
         _rotation = property.rotation;
     };
 

--- a/adk/data/include/HeadBlock.h
+++ b/adk/data/include/HeadBlock.h
@@ -20,7 +20,7 @@ class HeadBlock : public Block {
         _friction = property.friction;
         _light_emission = property.light_emission;
         _loot = property.loot;
-        _color = property.colour;
+        _color = property.color;
         _rotation = property.rotation;
     }
 

--- a/adk/data/include/SaplingBlock.h
+++ b/adk/data/include/SaplingBlock.h
@@ -31,7 +31,7 @@ class SaplingBlock : public BushBlock {
         _friction = property.friction;
         _light_emission = property.light_emission;
         _loot = property.loot;
-        _color = property.colour;
+        _color = property.color;
         _rotation = property.rotation;
         _number_of_properties = number_of_properties;
         _structure = structure;
@@ -54,7 +54,7 @@ class SaplingBlock : public BushBlock {
         _friction = property.friction;
         _light_emission = property.light_emission;
         _loot = property.loot;
-        _color = property.colour;
+        _color = property.color;
         _rotation = property.rotation;
         _number_of_properties = number_of_properties;
         _structure = structure;

--- a/adk/data/include/generator/BlockState.h
+++ b/adk/data/include/generator/BlockState.h
@@ -17,8 +17,8 @@ void simpleBlock(std::string block) {
     std::ifstream TempFile("./BP/blocks/" + block + ".json");
     nlohmann::json j = nlohmann::json::parse(TempFile);
 
-    j["minecraft:block"]["components"]["material_instances"]["*"]["texture"] =
-        block;
+    j["minecraft:block"]["components"]["minecraft:material_instances"]["*"]
+     ["texture"] = block;
 
     TempFile.close();
     std::ofstream MyFile("./BP/blocks/" + block + ".json");
@@ -35,13 +35,13 @@ void axisBlock(std::string block, std::string sides, std::string ends) {
     std::ifstream TempFile("./BP/blocks/" + block + ".json");
     nlohmann::json j = nlohmann::json::parse(TempFile);
 
-    j["minecraft:block"]["components"]["material_instances"]["*"]["texture"] =
-        sides;
-    j["minecraft:block"]["components"]["material_instances"]["ends"]
+    j["minecraft:block"]["components"]["minecraft:material_instances"]["*"]
+     ["texture"] = sides;
+    j["minecraft:block"]["components"]["minecraft:material_instances"]["ends"]
      ["texture"] = ends;
-    j["minecraft:block"]["components"]["material_instances"]["up"]["texture"] =
-        "ends";
-    j["minecraft:block"]["components"]["material_instances"]["down"]
+    j["minecraft:block"]["components"]["minecraft:material_instances"]["up"]
+     ["texture"] = "ends";
+    j["minecraft:block"]["components"]["minecraft:material_instances"]["down"]
      ["texture"] = "ends";
 
     TempFile.close();
@@ -60,8 +60,8 @@ void customBlock(std::string block, std::string model, std::string texture) {
     nlohmann::json j = nlohmann::json::parse(TempFile);
 
     j["minecraft:block"]["components"]["minecraft:geometry"] = model;
-    j["minecraft:block"]["components"]["material_instances"]["*"]["texture"] =
-        texture;
+    j["minecraft:block"]["components"]["minecraft:material_instances"]["*"]
+     ["texture"] = texture;
 
     TempFile.close();
     std::ofstream MyFile("./BP/blocks/" + block + ".json");


### PR DESCRIPTION
- Changed all instance of `colour` to `color` to match American Spelling
- Fixed a typo, `destory`, which caused the `destructible_by_mining` component to not work
- Added `decrement_stack` to `CandleBlock` class
- Fixed bug where `BlockState` would generate `material_instances` instead of `minecraft:material_instances`